### PR TITLE
Escape html find replace

### DIFF
--- a/src/dialogs/story-search/index.js
+++ b/src/dialogs/story-search/index.js
@@ -57,14 +57,19 @@ module.exports = Vue.extend({
 
 				/*
 				Replaces HTML tags with their respective unicodes to prevent
-				unwanted execution of HTML code.
+				unwanted execution of HTML code. If unicode is present
+				escape the unicode. If both are present, both can't be escaped
+				so prioritize escaping HTML.
 				*/
-				if (passageText.includes("&lt") || passageText.includes("&gt")) { // If user types &lt or &gt in their passage
+				let hasUnicodeOnly = (passageText.includes("&lt") || passageText.includes("&gt"))
+				&& !(passageText.includes("<") || passageText.includes(">"));
+
+				if (hasUnicodeOnly) {
 					passageName = passageName.replaceAll("&lt", "&amp;lt").replaceAll("&gt", "&amp;gt");
 					passageText = passageText.replaceAll("&lt", "&amp;lt").replaceAll("&gt", "&amp;gt");
 					this.search = this.search.replaceAll("&lt", "&amp;lt").replaceAll("&gt", "&amp;gt");
 				}
-				else { // If user types < or > in their passage
+				else {
 					passageName = passageName.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 					passageText = passageText.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 					this.search = this.search.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
@@ -104,10 +109,10 @@ module.exports = Vue.extend({
 				/*
 				Reverts this.search back to its original state.
 				*/
-				if (passage.text.includes("&lt") || passage.text.includes("&gt")) { // If user types &lt or &gt in their passage
+				if (hasUnicodeOnly) {
 					this.search = this.search.replaceAll("&amp;lt", "&lt").replaceAll("&amp;gt", "&gt");
 				}
-				else { // If user types < or > in their passage
+				else {
 					this.search = this.search.replaceAll("&lt;", "<").replaceAll("&gt;", ">");
 				}
 

--- a/src/dialogs/story-search/index.js
+++ b/src/dialogs/story-search/index.js
@@ -31,9 +31,6 @@ module.exports = Vue.extend({
 			}
 
 			let source = this.search;
-			// source = source.replaceAll("<", "&lt");
-			// source = source.replaceAll(">", "&gt");
-
 			/*
 			Escape regular expression characters in what the user typed unless
 			they indicated that they're using a regexp.
@@ -54,8 +51,6 @@ module.exports = Vue.extend({
 			this.working = true;
 
 			let result = this.story.passages.reduce((matches, passage) => {
-				// passage.text = passage.text.replaceAll("<", "&lt");
-				// passage.text = passage.text.replaceAll(">", "&gt");
 				let numMatches = 0;
 				let passageName = passage.name;
 				let passageText = passage.text;
@@ -65,15 +60,10 @@ module.exports = Vue.extend({
 				passageName = passageName.replaceAll('>', "&gt;");
 				let highlightedName = passageName;
 				let highlightedText = passageText;
-
 				this.search = this.search.replaceAll("<", "&lt;");
 				this.search = this.search.replaceAll(">", "&gt;");
 				let textMatches = passageText.match(this.searchRegexp);
-
 				let nameMatches = passageName.match(this.searchRegexp);
-				// console.log(this.search);
-				// this.search = "nick";
-				//console.log(this.searchRegexp); // changing what this.search is updates this.searchRegexp!
 
 				if (textMatches) {
 					numMatches += textMatches.length;
@@ -90,18 +80,6 @@ module.exports = Vue.extend({
 					);
 				}
 
-				// if (this.searchNames) {
-				// 	let nameMatches = passageName.match(this.searchRegexp);
-
-				// 	if (nameMatches) {
-				// 		numMatches += nameMatches.length;
-				// 		highlightedName = passageName.replace(
-				// 			this.searchRegexp,
-				// 			'<span class="highlight">$1</span>'
-				// 		);
-				// 	}
-				// }
-
 				if (numMatches > 0) {
 					matches.push({
 						passage,
@@ -110,11 +88,8 @@ module.exports = Vue.extend({
 						highlightedText
 					});
 				}
-				// this.searchRegexp = this.searchRegexp.replaceAll("&lt", "<");
-				// this.searchRegexp = this.searchRegexp.replaceAll("&gt", ">");
 				this.search = this.search.replaceAll("&lt;", "<");
 				this.search = this.search.replaceAll("&gt;", ">");
-				//console.log(this.searchRegexp);
 
 				return matches;
 			}, []);

--- a/src/dialogs/story-search/index.js
+++ b/src/dialogs/story-search/index.js
@@ -31,6 +31,8 @@ module.exports = Vue.extend({
 			}
 
 			let source = this.search;
+			// source = source.replaceAll("<", "&lt");
+			// source = source.replaceAll(">", "&gt");
 
 			/*
 			Escape regular expression characters in what the user typed unless
@@ -52,12 +54,26 @@ module.exports = Vue.extend({
 			this.working = true;
 
 			let result = this.story.passages.reduce((matches, passage) => {
+				// passage.text = passage.text.replaceAll("<", "&lt");
+				// passage.text = passage.text.replaceAll(">", "&gt");
 				let numMatches = 0;
 				let passageName = passage.name;
 				let passageText = passage.text;
+				passageText = passageText.replaceAll("<", "&lt;");
+				passageText = passageText.replaceAll('>', "&gt;");
+				passageName = passageName.replaceAll("<", "&lt;");
+				passageName = passageName.replaceAll('>', "&gt;");
 				let highlightedName = passageName;
 				let highlightedText = passageText;
+
+				this.search = this.search.replaceAll("<", "&lt;");
+				this.search = this.search.replaceAll(">", "&gt;");
 				let textMatches = passageText.match(this.searchRegexp);
+
+				let nameMatches = passageName.match(this.searchRegexp);
+				// console.log(this.search);
+				// this.search = "nick";
+				//console.log(this.searchRegexp); // changing what this.search is updates this.searchRegexp!
 
 				if (textMatches) {
 					numMatches += textMatches.length;
@@ -66,18 +82,25 @@ module.exports = Vue.extend({
 						'<span class="highlight">$1</span>'
 					);
 				}
-
-				if (this.searchNames) {
-					let nameMatches = passageName.match(this.searchRegexp);
-
-					if (nameMatches) {
-						numMatches += nameMatches.length;
-						highlightedName = passageName.replace(
-							this.searchRegexp,
-							'<span class="highlight">$1</span>'
-						);
-					}
+				if (nameMatches) {
+					numMatches += nameMatches.length;
+					highlightedName = passageName.replace(
+						this.searchRegexp,
+						'<span class="highlight">$1</span>'
+					);
 				}
+
+				// if (this.searchNames) {
+				// 	let nameMatches = passageName.match(this.searchRegexp);
+
+				// 	if (nameMatches) {
+				// 		numMatches += nameMatches.length;
+				// 		highlightedName = passageName.replace(
+				// 			this.searchRegexp,
+				// 			'<span class="highlight">$1</span>'
+				// 		);
+				// 	}
+				// }
 
 				if (numMatches > 0) {
 					matches.push({
@@ -87,6 +110,11 @@ module.exports = Vue.extend({
 						highlightedText
 					});
 				}
+				// this.searchRegexp = this.searchRegexp.replaceAll("&lt", "<");
+				// this.searchRegexp = this.searchRegexp.replaceAll("&gt", ">");
+				this.search = this.search.replaceAll("&lt;", "<");
+				this.search = this.search.replaceAll("&gt;", ">");
+				//console.log(this.searchRegexp);
 
 				return matches;
 			}, []);

--- a/src/dialogs/story-search/index.js
+++ b/src/dialogs/story-search/index.js
@@ -54,16 +54,24 @@ module.exports = Vue.extend({
 				let numMatches = 0;
 				let passageName = passage.name;
 				let passageText = passage.text;
-				passageText = passageText.replaceAll("<", "&lt;");
-				passageText = passageText.replaceAll('>', "&gt;");
-				passageName = passageName.replaceAll("<", "&lt;");
-				passageName = passageName.replaceAll('>', "&gt;");
+
+				/*
+				Replaces HTML tags with their respective unicodes to prevent
+				unwanted execution of HTML code.
+				*/
+				if (passageText.includes("&lt") || passageText.includes("&gt")) { // If user types &lt or &gt in their passage
+					passageName = passageName.replaceAll("&lt", "&amp;lt").replaceAll("&gt", "&amp;gt");
+					passageText = passageText.replaceAll("&lt", "&amp;lt").replaceAll("&gt", "&amp;gt");
+					this.search = this.search.replaceAll("&lt", "&amp;lt").replaceAll("&gt", "&amp;gt");
+				}
+				else { // If user types < or > in their passage
+					passageName = passageName.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+					passageText = passageText.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+					this.search = this.search.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+				}
 				let highlightedName = passageName;
 				let highlightedText = passageText;
-				this.search = this.search.replaceAll("<", "&lt;");
-				this.search = this.search.replaceAll(">", "&gt;");
 				let textMatches = passageText.match(this.searchRegexp);
-				let nameMatches = passageName.match(this.searchRegexp);
 
 				if (textMatches) {
 					numMatches += textMatches.length;
@@ -72,12 +80,17 @@ module.exports = Vue.extend({
 						'<span class="highlight">$1</span>'
 					);
 				}
-				if (nameMatches) {
-					numMatches += nameMatches.length;
-					highlightedName = passageName.replace(
-						this.searchRegexp,
-						'<span class="highlight">$1</span>'
-					);
+
+				if (this.searchNames) {
+					let nameMatches = passageName.match(this.searchRegexp);
+
+					if (nameMatches) {
+						numMatches += nameMatches.length;
+						highlightedName = passageName.replace(
+							this.searchRegexp,
+							'<span class="highlight">$1</span>'
+						);
+					}
 				}
 
 				if (numMatches > 0) {
@@ -88,8 +101,15 @@ module.exports = Vue.extend({
 						highlightedText
 					});
 				}
-				this.search = this.search.replaceAll("&lt;", "<");
-				this.search = this.search.replaceAll("&gt;", ">");
+				/*
+				Reverts this.search back to its original state.
+				*/
+				if (passage.text.includes("&lt") || passage.text.includes("&gt")) { // If user types &lt or &gt in their passage
+					this.search = this.search.replaceAll("&amp;lt", "&lt").replaceAll("&amp;gt", "&gt");
+				}
+				else { // If user types < or > in their passage
+					this.search = this.search.replaceAll("&lt;", "<").replaceAll("&gt;", ">");
+				}
 
 				return matches;
 			}, []);

--- a/src/dialogs/story-search/result.js
+++ b/src/dialogs/story-search/result.js
@@ -47,10 +47,6 @@ module.exports = Vue.extend({
 		},
 
 		replace() {
-			// this.searchRegexp = this.searchRegexp.replace("<", "&lt");
-			// this.searchRegexp = this.searchRegexp.replace(">", "&gt");
-			// this.replaceWith = this.replaceWith.replace("<", "&lt");
-			// this.replaceWith = this.replaceWith.replace(">", "&gt");			
 			const name = this.searchNames ?
 				this.match.passage.name.replace(
 					this.searchRegexp,

--- a/src/dialogs/story-search/result.js
+++ b/src/dialogs/story-search/result.js
@@ -47,6 +47,10 @@ module.exports = Vue.extend({
 		},
 
 		replace() {
+			// this.searchRegexp = this.searchRegexp.replace("<", "&lt");
+			// this.searchRegexp = this.searchRegexp.replace(">", "&gt");
+			// this.replaceWith = this.replaceWith.replace("<", "&lt");
+			// this.replaceWith = this.replaceWith.replace(">", "&gt");			
 			const name = this.searchNames ?
 				this.match.passage.name.replace(
 					this.searchRegexp,


### PR DESCRIPTION
🛑 **Only PRs related to localization are being accepted for Twine 2.4 right now.** \
🛑 **Only PRs that fix bugs will be accepted for Twine 2.3. No PRs that add new features or modify existing functionality will be accepted.**

# Description

Fixed visual issue where HTML code isn't displayed correctly in the Find/Replace preview box.
Before Fix:
![BeforeFix](https://user-images.githubusercontent.com/106285122/182497504-102ef153-e7e5-4f3b-9069-703c82518595.PNG)
After Fix:
![AfterFix](https://user-images.githubusercontent.com/106285122/182497558-62f67c43-f1a6-4ec5-9d99-e92a65ec79e7.PNG)
![AfterFix2](https://user-images.githubusercontent.com/106285122/182497564-1e1d28ff-d4eb-40cb-a4c1-b553c992bcf6.PNG)\
There are two limitations with this fix: if the user enters "&amp" it will be displayed as "&" in the preview box and if the user enters both "<"/">" and "&lt"/"&gt" only the HTML will be escaped. However, the encountering of these two limitations are unlikely and we believe the additional functionality outweighs these limitations.

# Issues fixed

https://github.com/klembot/twinejs/issues/1104

# Credit

Please put an X in *one* of the squares below only.

[X] I would like to be credited in the application as: Nicholas Chung, Saksham Gurung, and Tamara Andrade \
[ ] I would not like my name to appear in the application credits.

# Presubmission checklist

Put an X in the squares below to indicate you've done each step.

[X] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[X] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[X] I have read and agree to abide by this project's Code of Conduct.